### PR TITLE
CHE-2033 Remove Native Git implementation

### DIFF
--- a/assembly/openshift-plugin-assembly-wsagent-war/pom.xml
+++ b/assembly/openshift-plugin-assembly-wsagent-war/pom.xml
@@ -84,7 +84,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-git-impl-native</artifactId>
+            <artifactId>che-core-git-impl-jgit</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>

--- a/assembly/openshift-plugin-assembly-wsagent-war/pom.xml
+++ b/assembly/openshift-plugin-assembly-wsagent-war/pom.xml
@@ -108,10 +108,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-plugin-git-provider-che</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-github-provider-github</artifactId>
             <type>jar</type>
         </dependency>

--- a/assembly/openshift-plugin-assembly-wsagent-war/src/main/java/org/eclipse/che/wsagent/server/WsAgentModule.java
+++ b/assembly/openshift-plugin-assembly-wsagent-war/src/main/java/org/eclipse/che/wsagent/server/WsAgentModule.java
@@ -30,10 +30,10 @@ import org.eclipse.che.api.git.LocalGitUserResolver;
 import org.eclipse.che.api.project.server.ProjectApiModule;
 import org.eclipse.che.api.ssh.server.HttpSshServiceClient;
 import org.eclipse.che.api.ssh.server.SshServiceClient;
-import org.eclipse.che.api.user.server.dao.PreferenceDao;
+import org.eclipse.che.api.user.server.spi.PreferenceDao;
 import org.eclipse.che.commons.lang.Pair;
 import org.eclipse.che.everrest.CheAsynchronousJobPool;
-import org.eclipse.che.git.impl.nativegit.NativeGitConnectionFactory;
+import org.eclipse.che.git.impl.jgit.JGitConnectionFactory;
 import org.eclipse.che.ide.ext.openshift.server.inject.OpenshiftModule;
 import org.eclipse.che.inject.DynaModule;
 import org.eclipse.che.security.oauth.RemoteOAuthTokenProvider;
@@ -69,7 +69,7 @@ public class WsAgentModule extends AbstractModule {
         install(new OpenshiftModule());
 
         bind(GitUserResolver.class).to(LocalGitUserResolver.class);
-        bind(GitConnectionFactory.class).to(NativeGitConnectionFactory.class);
+        bind(GitConnectionFactory.class).to(JGitConnectionFactory.class);
 
         bind(AsynchronousJobPool.class).to(CheAsynchronousJobPool.class);
         bind(ServiceBindingHelper.bindingKey(AsynchronousJobService.class, "/async/{ws-id}")).to(AsynchronousJobService.class);


### PR DESCRIPTION
Use JGit implemenation as Native Git is being removed from Che: https://github.com/eclipse/che/issues/2033
