### PR TITLE
CHE-3733 Exclude assembly's bin folder from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ Icon?
 Thumbs.db
 */overlays
 *~
+
+# Assembly #
+############
+!assembly/openshift-plugin-assembly-main/src/assembly/bin


### PR DESCRIPTION
assembly/openshift-plugin-assembly-main/src/assembly/bin folder is no longer ignored by gitignore

Original issue: https://github.com/eclipse/che/issues/3733

#### Changelog
Exclude `assembly/openshift-plugin-assembly-main/src/assembly/bin` source folder from gitignore