### PR TITLE
CHE-4596: move che-plugin-machine-ext-client to IDE core

### DIFF
--- a/assembly/assembly-ide-war/pom.xml
+++ b/assembly/assembly-ide-war/pom.xml
@@ -205,10 +205,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-plugin-machine-ext-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-machine-ssh-client</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Fix problems related to moving `machine-plugin`.